### PR TITLE
Updates to deployed zkApp

### DIFF
--- a/lambda-payouts/index.js
+++ b/lambda-payouts/index.js
@@ -69,7 +69,7 @@ exports.handler = async (event) => {
     let indexEvent = event.queryStringParameters.index || 0;
     //const eventKey = "B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg";
     //const epochEvent = "39";
-    //let indexEvent = 55;
+    //let indexEvent = 58;
     //const limit = 9;
     // TODO REPLACE THIS WITH OUR OWN KEY SERVER BY SECRET ENV
     const privateKey = snarkyjs_1.PrivateKey.fromBase58("EKF65JKw9Q1XWLDZyZNGysBbYG21QbJf3a4xnEoZPZ28LKYGMw53");
@@ -134,6 +134,15 @@ exports.handler = async (event) => {
         });
         indexEvent++;
     });
+    // Handle the case where we have less than 8
+    for (let i = trimmedStakingData.length; i < 8; i++) {
+        signedData = signedData.concat(snarkyjs_1.UInt32.from(0).toFields()).concat(snarkyjs_1.PublicKey.empty().toFields()).concat(snarkyjs_1.UInt64.from(0).toFields());
+        outputArray.push({
+            index: snarkyjs_1.UInt32.from(0),
+            publicKey: snarkyjs_1.PublicKey.empty(),
+            rewards: snarkyjs_1.UInt64.from(0)
+        });
+    }
     // Add data for the fee payout
     const epochToField = snarkyjs_1.UInt32.from(epochEvent);
     const numDelegatesToField = snarkyjs_1.UInt32.from(numDelegators);

--- a/lambda-payouts/index.ts
+++ b/lambda-payouts/index.ts
@@ -95,7 +95,7 @@ exports.handler = async (event) => {
 
   //const eventKey = "B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg";
   //const epochEvent = "39";
-  //let indexEvent = 55;
+  //let indexEvent = 58;
   //const limit = 9;
 
   // TODO REPLACE THIS WITH OUR OWN KEY SERVER BY SECRET ENV
@@ -187,6 +187,20 @@ exports.handler = async (event) => {
 
     indexEvent++;
   });
+
+  // Handle the case where we have less than 8
+  for (let i = trimmedStakingData.length; i < 8; i++) {
+
+    signedData = signedData.concat(UInt32.from(0).toFields()).concat(PublicKey.empty().toFields()).concat(UInt64.from(0).toFields());
+
+    outputArray.push({
+      index: UInt32.from(0),
+      publicKey: PublicKey.empty(),
+      rewards: UInt64.from(0)
+    });
+
+
+  }
 
   // Add data for the fee payout
   const epochToField = UInt32.from(epochEvent);

--- a/pool-payout-zkapp/src/PoolPayout.test.ts
+++ b/pool-payout-zkapp/src/PoolPayout.test.ts
@@ -96,11 +96,11 @@ describe('pool payout', () => {
     };
     rewardFields.rewards[0].index = Field(0);
     rewardFields.rewards[0].publicKey = delegator1PrivateKey.toPublicKey();
-    rewardFields.rewards[0].rewards = UInt64.from(1000);
+    rewardFields.rewards[0].rewards = UInt64.from(1000).mul(1000); // TODO while testing use 1000th of the rewards to make it easier
 
     let feePayout = new FeePayout({
       numDelegates: Field(1),
-      payout: UInt64.from(1000),
+      payout: UInt64.from(1000).mul(1000), // TODO while testing use 1000th of the rewards to make it easy
     })
 
     let signedData: Field[] = [];

--- a/pool-payout-zkapp/src/PoolPayout.test.ts
+++ b/pool-payout-zkapp/src/PoolPayout.test.ts
@@ -91,7 +91,7 @@ describe('pool payout', () => {
      */
     let rewardFields: Rewards2 = {
       rewards: [
-        Reward.blank(), Reward.blank()
+        Reward.blank(), Reward.blank(), Reward.blank(), Reward.blank(), Reward.blank(), Reward.blank(), Reward.blank(), Reward.blank()
       ]
     };
     rewardFields.rewards[0].index = Field(0);

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -1,11 +1,3 @@
-/*
-TODO use the onchain data for the fee payout
-Use the on chain data for calculating the rewards
-Handle the case where we have less than 9 in the array
-Tidy up keys in scripts
-Pass the index by variable to the script
-*/
-
 import {
   Field,
   SmartContract,

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -166,7 +166,7 @@ export class PoolPayout extends SmartContract {
       let payoutPercentage = UInt64.from(100).sub(UInt64.from(5)); //TODO use on-chain variable here
       let payout = Circuit.if(
         accountIsNotEmpty,
-        (() => reward.rewards.mul(payoutPercentage).div(100).div(100))(), // TODO Temp make this smaller as easier to pay
+        (() => reward.rewards.mul(payoutPercentage).div(100).div(1000))(), // TODO Temp make this smaller as easier to pay
         (() => UInt64.zero)()
       )
       payout.assertLte(reward.rewards);
@@ -208,7 +208,7 @@ export class PoolPayout extends SmartContract {
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
-      (() => [feePayout.payout.mul(5).div(100).div(100), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
+      (() => [feePayout.payout.mul(5).div(100).div(1000), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
       (() => [UInt64.from(0), transactionIndex, epoch])()
     )
 

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -54,7 +54,7 @@ export class FeePayout extends Struct({
 }) { }
 
 export class Rewards2 extends Struct({
-  rewards: Circuit.array(Reward, 2),
+  rewards: Circuit.array(Reward, 8),
 }) { }
 
 export class PoolPayout extends SmartContract {
@@ -163,10 +163,10 @@ export class PoolPayout extends SmartContract {
       signedData = signedData.concat(reward.index.toFields()).concat(reward.publicKey.toFields()).concat(reward.rewards.toFields());
 
       // calculate the rewards
-      let payoutPercentage = UInt64.from(100).sub(UInt64.from(5));
+      let payoutPercentage = UInt64.from(100).sub(UInt64.from(5)); //TODO use on-chain variable here
       let payout = Circuit.if(
         accountIsNotEmpty,
-        (() => reward.rewards.mul(payoutPercentage).div(100))(), // Temp make this smaller as easier to pay
+        (() => reward.rewards.mul(payoutPercentage).div(100).div(100))(), // TODO Temp make this smaller as easier to pay
         (() => UInt64.zero)()
       )
       payout.assertLte(reward.rewards);
@@ -208,7 +208,7 @@ export class PoolPayout extends SmartContract {
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
-      (() => [feePayout.payout.mul(5).div(100), Field(0), epoch.add(1)])(),
+      (() => [feePayout.payout.mul(5).div(100).div(100), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
       (() => [UInt64.from(0), currentIndex, epoch])()
     )
 

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -209,7 +209,7 @@ export class PoolPayout extends SmartContract {
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
       (() => [feePayout.payout.mul(5).div(100).div(100), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
-      (() => [UInt64.from(0), currentIndex, epoch])()
+      (() => [UInt64.from(0), transactionIndex, epoch])()
     )
 
     Circuit.asProver(() => {

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -22,12 +22,11 @@ const ORACLE_PUBLIC_KEY = 'B62qphyUJg3TjMKi74T2rF8Yer5rQjBr1UyEG7Wg9XEYAHjaSiSqF
 // Using this value as a test as a nice number of delegates
 const VALIDATOR_PUBLIC_KEY = 'B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg';
 
-// This matches our output
 export class Reward extends Struct({
   index: Field,
   publicKey: PublicKey,
   rewards: UInt64
-}) { // Have the data concatenated here?
+}) {
   static blank(): Reward {
     return new Reward({
       index: Field(0),

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -51,7 +51,7 @@ import {
   // Need to track these manually offline
   let feePayerNonce = 0;
   let zkAppAddressNonce = 0;
-  let index = 16;
+  let index = 56;
   let epochOracle = 39;
 
   // TODO need to manually set the fee payer nonce and zkApp nonce, plus keep track of the index. 

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -51,14 +51,15 @@ import {
   // Need to track these manually offline
   let feePayerNonce = 0;
   let zkAppAddressNonce = 0;
-  let index = 0;
+  let index = 16;
+  let epochOracle = 39;
 
   // TODO need to manually set the fee payer nonce and zkApp nonce, plus keep track of the index. 
   // Why? Because we want to sign these all offline and get more than 1 tx in a block
 
   // Function URL
   // TODO pass the epoch via the command line - hardcoded here for testing
-  let functionUrl = "https://kodem6bg3gatbplrmoiy2sxnty0wfrhp.lambda-url.us-west-2.on.aws/?publicKey=B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg&epoch=39&index=" + index;
+  let functionUrl = "https://kodem6bg3gatbplrmoiy2sxnty0wfrhp.lambda-url.us-west-2.on.aws/?publicKey=B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg&epoch=" + epochOracle + "&index=" + index;
 
   console.log(functionUrl);
 

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -51,8 +51,8 @@ import {
   // Need to track these manually offline
   let feePayerNonce = 0;
   let zkAppAddressNonce = 0;
-  let index = 56;
-  let epochOracle = 39;
+  let index = 0;
+  let epochOracle = 40;
 
   // TODO need to manually set the fee payer nonce and zkApp nonce, plus keep track of the index. 
   // Why? Because we want to sign these all offline and get more than 1 tx in a block

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -113,7 +113,7 @@ import {
 
     console.log("Sending transaction");
     console.log(transaction.toPretty());
-    //await transaction.send();
+    await transaction.send();
   } catch (error: any) {
     console.log("There was an issue");
     console.log(error.message);


### PR DESCRIPTION
Few changes to get this to work on Berkeley:

* Increased the number of payouts to 8
* Made the rewards smaller to make it easier to work with testnet funds
* Updated the oracle to match empty rewards signature

With this paid all epoch 39 and started epoch 40, after correctly incrementing. zkapp deployed to https://berkeley.minaexplorer.com/wallet/B62qnLCwU65ZC7yuhPc7hGS2wwSokms4m3zbkU6Nk9nphRH8PtMxSmb