### PR TITLE
Setting permissions on zkApp

### DIFF
--- a/pool-payout-zkapp/src/PoolPayout.test.ts
+++ b/pool-payout-zkapp/src/PoolPayout.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'snarkyjs';
 
 import { PoolPayout, Reward, Rewards2, FeePayout } from './PoolPayout';
-import { ORACLE_PRIVATE_KEY_TESTING, VALIDATOR_PRIVATE_KEY_TESTING } from './constants';
+import { ORACLE_PRIVATE_KEY_TESTING, VALIDATOR_PUBLIC_KEY_TESTING } from './constants';
 
 await isReady;
 await PoolPayout.compile();
@@ -22,7 +22,7 @@ describe('pool payout', () => {
 
   let deployerPrivateKey: PrivateKey;
   let delegator1PrivateKey: PrivateKey;
-  let validatorPrivateKey: PrivateKey;
+  let validatorPublicKey: PublicKey;
 
   beforeEach(async () => {
     const Local = Mina.LocalBlockchain();
@@ -33,7 +33,7 @@ describe('pool payout', () => {
 
     deployerPrivateKey = Local.testAccounts[0].privateKey;
     delegator1PrivateKey = Local.testAccounts[1].privateKey;
-    validatorPrivateKey = PrivateKey.fromBase58(VALIDATOR_PRIVATE_KEY_TESTING);
+    validatorPublicKey = PublicKey.fromBase58(VALIDATOR_PUBLIC_KEY_TESTING);
   });
 
   afterAll(async () => {
@@ -47,7 +47,7 @@ describe('pool payout', () => {
       AccountUpdate.fundNewAccount(deployerPrivateKey);
       pool.deploy({ zkappKey: zkappPrivateKey });
       const createValidatorAccount = AccountUpdate.create(deployerPrivateKey.toPublicKey());
-      createValidatorAccount.send({ to: validatorPrivateKey.toPublicKey(), amount: 1 });
+      createValidatorAccount.send({ to: validatorPublicKey, amount: 1 });
       createValidatorAccount.requireSignature();
     });
     tx.sign([deployerPrivateKey]);
@@ -58,10 +58,10 @@ describe('pool payout', () => {
 
     const startingDelegator1Balance = Mina.getAccount(delegator1PrivateKey.toPublicKey()).balance;
     const startingZkAppBalance = Mina.getAccount(zkappAddress).balance;
-    const startingValidatorBalance = Mina.getAccount(validatorPrivateKey.toPublicKey()).balance;
+    const startingValidatorBalance = Mina.getAccount(validatorPublicKey).balance;
     console.log(`Delegator Starting Balance: ${startingDelegator1Balance.toString()} ${delegator1PrivateKey.toPublicKey().toBase58()}`)
     console.log(`ZKAPP starting balance: ${startingZkAppBalance.toString()} ${zkappPrivateKey.toPublicKey().toBase58()}`)
-    console.log(`Validator starting balance: ${startingValidatorBalance.toString()} ${validatorPrivateKey.toPublicKey().toBase58()}`)
+    console.log(`Validator starting balance: ${startingValidatorBalance.toString()} ${validatorPublicKey.toBase58()}`)
 
 
     /**
@@ -76,11 +76,11 @@ describe('pool payout', () => {
     };
     rewardFields.rewards[0].index = Field(0);
     rewardFields.rewards[0].publicKey = delegator1PrivateKey.toPublicKey();
-    rewardFields.rewards[0].rewards = UInt64.from(1_000_000_000).mul(1000); // TODO while testing use 1000th of the rewards to make it easier
+    rewardFields.rewards[0].rewards = UInt64.from(1000).mul(1000); // TODO while testing use 1000th of the rewards to make it easier
 
     let feePayout = new FeePayout({
       numDelegates: Field(1),
-      payout: UInt64.from(1_000_000_000).mul(1000), // TODO while testing use 1000th of the rewards to make it easy
+      payout: UInt64.from(1000).mul(1000), // TODO while testing use 1000th of the rewards to make it easy
     })
 
     let signedData: Field[] = [];
@@ -109,7 +109,7 @@ describe('pool payout', () => {
 
     // Payouts | Delegator 1: 950, Validator: 50
     const delegator1Balance = Mina.getAccount(delegator1PrivateKey.toPublicKey()).balance;
-    const validatorBalance = Mina.getAccount(validatorPrivateKey.toPublicKey()).balance;
+    const validatorBalance = Mina.getAccount(validatorPublicKey).balance;
     expect(delegator1Balance.sub(startingDelegator1Balance).toString()).toBe('950');
     expect(validatorBalance.sub(startingValidatorBalance).toString()).toBe('50');
 

--- a/pool-payout-zkapp/src/PoolPayout.test.ts
+++ b/pool-payout-zkapp/src/PoolPayout.test.ts
@@ -57,19 +57,10 @@ describe('pool payout', () => {
     tx.sign([deployerPrivateKey]);
     await tx.send();
 
+    // This matches what we have deployed in our init() method
     const startingEpoch = Field(39);
     const startingIndex = Field(0);
     const testOracle = PrivateKey.fromBase58(ORACLE_PRIVATE_KEY_TESTING).toPublicKey();
-
-    const tx2 = await Mina.transaction(deployerPrivateKey, () => {
-      pool.updateEpoch(startingEpoch);
-      pool.updateIndex(startingIndex);
-      pool.updateOracle(testOracle);
-      pool.updateValidator(validatorPrivateKey.toPublicKey());
-    });
-    tx2.sign([deployerPrivateKey, zkappPrivateKey]);
-    await tx2.prove();
-    await tx2.send();
 
     const startingDelegator1Balance = Mina.getAccount(delegator1PrivateKey.toPublicKey()).balance;
     const startingZkAppBalance = Mina.getAccount(zkappAddress).balance;
@@ -111,12 +102,15 @@ describe('pool payout', () => {
     )
 
     // Make the payouts
-    let tx3 = await Mina.transaction(deployerPrivateKey, () => {
+    let tx2 = await Mina.transaction(deployerPrivateKey, () => {
       pool.sendReward(rewardFields, feePayout, startingEpoch, signature);
     });
-    console.log("Proving transaction tx3");
-    await tx3.prove();
-    await tx3.send();
+    console.log("Proving transaction");
+    await tx2.prove();
+
+    console.log("Sending transaction");
+    console.log(tx2.toPretty());
+    await tx2.send();
 
     // Payouts | Delegator 1: 950, Validator: 50
     const delegator1Balance = Mina.getAccount(delegator1PrivateKey.toPublicKey()).balance;

--- a/pool-payout-zkapp/src/PoolPayout.test.ts
+++ b/pool-payout-zkapp/src/PoolPayout.test.ts
@@ -5,13 +5,8 @@ import {
   PrivateKey,
   PublicKey,
   AccountUpdate,
-  MerkleMap,
   Field,
-  Poseidon,
-  Circuit,
   Signature,
-  Encryption,
-  Int64,
   UInt64,
 } from 'snarkyjs';
 
@@ -62,19 +57,9 @@ describe('pool payout', () => {
     tx.sign([deployerPrivateKey]);
     await tx.send();
 
-    const startingEpoch = Field(10);
+    const startingEpoch = Field(39);
     const startingIndex = Field(0);
     const testOracle = PrivateKey.fromBase58(ORACLE_PRIVATE_KEY_TESTING).toPublicKey();
-
-    const tx2 = await Mina.transaction(deployerPrivateKey, () => {
-      pool.updateEpoch(startingEpoch);
-      pool.updateIndex(startingIndex);
-      pool.updateOracle(testOracle);
-      pool.updateValidator(validatorPrivateKey.toPublicKey());
-    });
-    tx2.sign([deployerPrivateKey, zkappPrivateKey]);
-    await tx2.prove();
-    await tx2.send();
     
     const startingDelegator1Balance = Mina.getAccount(delegator1PrivateKey.toPublicKey()).balance;
     const startingZkAppBalance = Mina.getAccount(zkappAddress).balance;
@@ -113,6 +98,8 @@ describe('pool payout', () => {
       PrivateKey.fromBase58(ORACLE_PRIVATE_KEY_TESTING),
       signedData
     )
+
+    console.log(rewardFields, feePayout, startingEpoch, signature);
 
     let tx3 = await Mina.transaction(deployerPrivateKey, () => {
       pool.sendReward(rewardFields, feePayout, startingEpoch, signature);

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -160,7 +160,7 @@ export class PoolPayout extends SmartContract {
       signedData = signedData.concat(reward.index.toFields()).concat(reward.publicKey.toFields()).concat(reward.rewards.toFields());
 
       // Calculate the rewards
-      let payoutPercentage = UInt64.from(100).sub(UInt64.from(5)); //TODO use on-chain variable here
+      let payoutPercentage = UInt64.from(100).sub(feePercentage.toUInt64()); //TODO use on-chain variable here
       let payout = Circuit.if(
         accountIsNotEmpty,
         (() => reward.rewards.mul(payoutPercentage).div(100).div(1000))(), // TODO Temp make this smaller as easier to pay
@@ -204,7 +204,7 @@ export class PoolPayout extends SmartContract {
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
-      (() => [feePayout.payout.mul(5).div(100).div(1000), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
+      (() => [feePayout.payout.mul(feePercentage.toUInt64()).div(100).div(1000), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
       (() => [UInt64.from(0), transactionIndex, epoch])()
     )
 

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -160,7 +160,7 @@ export class PoolPayout extends SmartContract {
       signedData = signedData.concat(reward.index.toFields()).concat(reward.publicKey.toFields()).concat(reward.rewards.toFields());
 
       // Calculate the rewards
-      let payoutPercentage = UInt64.from(100).sub(feePercentage.toUInt64()); //TODO use on-chain variable here
+      let payoutPercentage = UInt64.from(100).sub(UInt64.from(5)); //TODO use on-chain variable here
       let payout = Circuit.if(
         accountIsNotEmpty,
         (() => reward.rewards.mul(payoutPercentage).div(100).div(1000))(), // TODO Temp make this smaller as easier to pay
@@ -204,7 +204,7 @@ export class PoolPayout extends SmartContract {
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
-      (() => [feePayout.payout.mul(feePercentage.toUInt64()).div(100).div(1000), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
+      (() => [feePayout.payout.mul(5).div(100).div(1000), Field(0), epoch.add(1)])(), //TODO temp make this much smaller for managable payouts
       (() => [UInt64.from(0), transactionIndex, epoch])()
     )
 

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -20,6 +20,15 @@ const ORACLE_PUBLIC_KEY = 'B62qphyUJg3TjMKi74T2rF8Yer5rQjBr1UyEG7Wg9XEYAHjaSiSqF
 // The public key of the block producer  - this cannot be changed once the contract is deployed.
 const VALIDATOR_PUBLIC_KEY = 'B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg';
 
+// The fee charged by the block producer
+const VALIDATOR_FEE = 5;
+
+// The initial epoch
+const INITIAL_EPOCH = 39;
+
+// The initial index
+const INITIAL_INDEX = 0;
+
 export class Reward extends Struct({
   index: Field,
   publicKey: PublicKey,
@@ -82,9 +91,9 @@ export class PoolPayout extends SmartContract {
       setZkappUri: Permissions.proof(),
     });
 
-    this.currentEpoch.set(Field(39));
-    this.currentIndex.set(Field(0));
-    this.feePercentage.set(UInt32.from(5));
+    this.currentEpoch.set(Field(INITIAL_EPOCH));
+    this.currentIndex.set(Field(INITIAL_INDEX));
+    this.feePercentage.set(UInt32.from(VALIDATOR_FEE));
     this.oraclePublicKey.set(PublicKey.fromBase58(ORACLE_PUBLIC_KEY));
     this.validatorPublicKey.set(PublicKey.fromBase58(VALIDATOR_PUBLIC_KEY));
   }
@@ -190,7 +199,7 @@ export class PoolPayout extends SmartContract {
     const validSignature = signature.verify(oraclePublicKey, signedData);
 
     // Check that the signature is valid if it isn't the whole transaction will fail
-    validSignature.assertTrue();
+    validSignature.assertTrue("The signature does not match that of the oracle");
 
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(

--- a/pool-payout-zkapp/src/PoolPayout.ts
+++ b/pool-payout-zkapp/src/PoolPayout.ts
@@ -4,7 +4,6 @@ import {
   state,
   State,
   method,
-  DeployArgs,
   Permissions,
   PublicKey,
   Signature,
@@ -13,13 +12,12 @@ import {
   Struct,
   Circuit,
   Bool,
-  PrivateKey,
 } from 'snarkyjs';
 
-// The public key of our trusted data provider
+// The public key of our trusted data provider - this cannot be changed once the contract is deployed.
 const ORACLE_PUBLIC_KEY = 'B62qphyUJg3TjMKi74T2rF8Yer5rQjBr1UyEG7Wg9XEYAHjaSiSqFv1';
 
-// Using this value as a test as a nice number of delegates
+// The public key of the block producer  - this cannot be changed once the contract is deployed.
 const VALIDATOR_PUBLIC_KEY = 'B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg';
 
 export class Reward extends Struct({
@@ -50,37 +48,38 @@ export class Rewards2 extends Struct({
 
 export class PoolPayout extends SmartContract {
 
-  // The latest epoch - will init this variable to have a starting point
+  // The latest epoch of the payout - this (and all state) can only be updated via a proof.
   @state(Field) currentEpoch = State<Field>();
 
-  // The current index of the payout run
+  // The current index of the payout run.
   @state(Field) currentIndex = State<Field>();
 
-  // Fee
+  // The fee of the block producer
   @state(UInt32) feePercentage = State<UInt32>();
 
-  // The Oracle public key (takes 2)
+  // The oracle public key (takes 2)
   @state(PublicKey) oraclePublicKey = State<PublicKey>();
 
-  // Validator key (takes 2)
+  // Block producer key (takes 2)
   @state(PublicKey) validatorPublicKey = State<PublicKey>();
 
-  // Deploy this - tighten permissions and move init stuff to an init method
-  deploy(args: DeployArgs) {
-    super.deploy(args);
+  // Set the initial state of the zkApp - this is done via a proof and can't then be updated again
+  init() {
+    super.init()
+
     this.setPermissions({
       ...Permissions.default(),
-      editSequenceState: Permissions.proofOrSignature(),
-      editState: Permissions.proofOrSignature(),
-      incrementNonce: Permissions.proofOrSignature(),
+      editSequenceState: Permissions.proof(), // No need for this
+      editState: Permissions.proof(), //TODO this should be proof only
+      incrementNonce: Permissions.proof(),
       receive: Permissions.none(),
-      send: Permissions.proofOrSignature(),
-      setDelegate: Permissions.impossible(),
-      setPermissions: Permissions.proofOrSignature(),
-      setTokenSymbol: Permissions.proofOrSignature(),
-      setVerificationKey: Permissions.proofOrSignature(),
-      setVotingFor: Permissions.proofOrSignature(),
-      setZkappUri: Permissions.impossible(),
+      send: Permissions.proof(), // Can only send via a proof
+      setDelegate: Permissions.proof(), // Could delegate to self 
+      setPermissions: Permissions.proof(),
+      setTokenSymbol: Permissions.proof(),
+      setVerificationKey: Permissions.proof(),
+      setVotingFor: Permissions.proof(),
+      setZkappUri: Permissions.proof(),
     });
 
     this.currentEpoch.set(Field(39));
@@ -90,56 +89,54 @@ export class PoolPayout extends SmartContract {
     this.validatorPublicKey.set(PublicKey.fromBase58(VALIDATOR_PUBLIC_KEY));
   }
 
-  @method
   updateEpoch(n: Field) {
     this.currentEpoch.set(n);
   }
 
-  @method
   updateIndex(i: Field) {
     this.currentIndex.set(i);
   }
 
-  @method
   updateOracle(publicKey: PublicKey) {
     this.oraclePublicKey.set(publicKey);
   }
 
-  @method
   updateValidator(publicKey: PublicKey) {
     this.validatorPublicKey.set(publicKey);
   }
 
-  // This method sends the rewards to the validator
-  // It verifies the index and epoch from the oracle
-  @method sendReward(accounts: Rewards2, feePayout: FeePayout, epoch: Field, signature: Signature) {
+  // This method sends rewards to delegators (up to 8) with a proof.
+  // If it is the last payout of the epoch, it sends the block producer rewards.
+  // It validates a signature from the oracle.
+  // Once complete it updates the state to the latest epoch and epoch.
+  @method
+  sendReward(accounts: Rewards2, feePayout: FeePayout, epoch: Field, signature: Signature) {
 
-    // get the current epoch
+    // Get the current epoch stored on-chain
     let currentEpoch = this.currentEpoch.get();
     this.currentEpoch.assertEquals(currentEpoch);
     epoch.assertEquals(currentEpoch, "The epoch must match");
 
-    // get the current index
+    // Get the current index stored on-chain
     let currentIndex = this.currentIndex.get();
     this.currentIndex.assertEquals(currentIndex);
     //Circuit.log(currentIndex);
 
-    // get the current fee
+    // Get the fee stored on-chain.
     const feePercentage = this.feePercentage.get();
-    //Circuit.log(feePercentage);
     this.feePercentage.assertEquals(feePercentage);
 
-    // Assert the validating key on chain
+    // Get the oracle public key stored on-chain.
     const oraclePublicKey = this.oraclePublicKey.get();
     this.oraclePublicKey.assertEquals(oraclePublicKey);
 
-    // get the current validator
+    // Get the block producer stored on-chain.
     let validatorPublicKey = this.validatorPublicKey.get();
     this.validatorPublicKey.assertEquals(validatorPublicKey);
 
     let signedData: Field[] = [];
 
-    // starting with the index on state, we can increment this variable during this transaction
+    // Starting with the index on state, we can increment this variable during this transaction
     let transactionIndex = currentIndex;
 
     for (let i = 0; i < accounts.rewards.length; i++) {
@@ -150,10 +147,10 @@ export class PoolPayout extends SmartContract {
       const indexCheck = Bool.or(Bool.not(accountIsNotEmpty), reward.index.equals(transactionIndex));
       indexCheck.assertEquals(Bool(true), "The index must match");
 
-      // reconstruct the signed data
+      // Reconstruct the signed data
       signedData = signedData.concat(reward.index.toFields()).concat(reward.publicKey.toFields()).concat(reward.rewards.toFields());
 
-      // calculate the rewards
+      // Calculate the rewards
       let payoutPercentage = UInt64.from(100).sub(UInt64.from(5)); //TODO use on-chain variable here
       let payout = Circuit.if(
         accountIsNotEmpty,
@@ -171,7 +168,7 @@ export class PoolPayout extends SmartContract {
         )
       })
 
-      // If we made it this far we can send the 
+      // If we made it this far we can create the account updates for the transaction. It can still fail when we assert the signature.
       this.send({
         to: reward.publicKey,
         amount: payout
@@ -192,10 +189,9 @@ export class PoolPayout extends SmartContract {
 
     const validSignature = signature.verify(oraclePublicKey, signedData);
 
-    // Check that the signature is valid if it isn't the transaction will fail
+    // Check that the signature is valid if it isn't the whole transaction will fail
     validSignature.assertTrue();
 
-    // Debugging control flow
     // If we are at the number of delegators we can send the fees to the onchain validated public key
     const [validatorCut, i, e] = Circuit.if(
       transactionIndex.gte(feePayout.numDelegates),
@@ -209,6 +205,7 @@ export class PoolPayout extends SmartContract {
       )
     })
 
+    // Update the on-chain state
     this.currentEpoch.set(e);
     this.currentIndex.set(i);
     this.send({

--- a/pool-payout-zkapp/src/constants.ts
+++ b/pool-payout-zkapp/src/constants.ts
@@ -2,4 +2,4 @@
 export const ORACLE_PRIVATE_KEY_TESTING = 'EKF65JKw9Q1XWLDZyZNGysBbYG21QbJf3a4xnEoZPZ28LKYGMw53';
 
 // Using this value as a test as a nice number of delegates
-export const VALIDATOR_PRIVATE_KEY_TESTING = 'EKEbWmsg5FMQq1u1ZT8Yvk1nRG1CdN3vDWRwtvQneqouxrMPr4Ag';
+export const VALIDATOR_PUBLIC_KEY_TESTING = 'B62qjhiEXP45KEk8Fch4FnYJQ7UMMfiR3hq9ZeMUZ8ia3MbfEteSYDg';

--- a/pool-payout-zkapp/src/constants.ts
+++ b/pool-payout-zkapp/src/constants.ts
@@ -1,5 +1,5 @@
 // The public key of our trusted data provider
-export const ORACLE_PRIVATE_KEY_TESTING = 'EKEFbCbJhwWYJ1ek5STBVuBKsVGtHMYo3Tfp173BNA5WGR4cBupk';
+export const ORACLE_PRIVATE_KEY_TESTING = 'EKF65JKw9Q1XWLDZyZNGysBbYG21QbJf3a4xnEoZPZ28LKYGMw53';
 
 // Using this value as a test as a nice number of delegates
 export const VALIDATOR_PRIVATE_KEY_TESTING = 'EKEbWmsg5FMQq1u1ZT8Yvk1nRG1CdN3vDWRwtvQneqouxrMPr4Ag';

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -34,7 +34,7 @@ import {
     'EKDvE7umHorQrXFq1AAwV4zEDLGtZuqpn1mhsgxvYRneUpKxRUF8'
   );
 
-  const zkAppAddress = PublicKey.fromBase58("B62qnLCwU65ZC7yuhPc7hGS2wwSokms4m3zbkU6Nk9nphRH8PtMxSmb");
+  const zkAppAddress = PublicKey.fromBase58("B62qqKSeseTN6Y13DY6xFidKdhRCu6xhECYhekhTuVYJss9sktsMPn3");
   const zkAppInstance = new PoolPayout(zkAppAddress);
 
   console.log('Compiling smart contract...');
@@ -52,7 +52,7 @@ import {
   let feePayerNonce = 0;
   let zkAppAddressNonce = 0;
   let index = 0;
-  let epochOracle = 40;
+  let epochOracle = 39;
 
   // TODO need to manually set the fee payer nonce and zkApp nonce, plus keep track of the index. 
   // Why? Because we want to sign these all offline and get more than 1 tx in a block

--- a/pool-payout-zkapp/src/main.ts
+++ b/pool-payout-zkapp/src/main.ts
@@ -8,11 +8,8 @@ import {
   Mina,
   PrivateKey,
   PublicKey,
-  UInt32,
   UInt64,
   Signature,
-  AccountUpdate,
-  Bool,
   Field,
   fetchAccount,
 } from 'snarkyjs';
@@ -51,7 +48,7 @@ import {
   // Need to track these manually offline
   let feePayerNonce = 0;
   let zkAppAddressNonce = 0;
-  let index = 0;
+  let index = 8;
   let epochOracle = 39;
 
   // TODO need to manually set the fee payer nonce and zkApp nonce, plus keep track of the index. 


### PR DESCRIPTION
Redeployed to `B62qqKSeseTN6Y13DY6xFidKdhRCu6xhECYhekhTuVYJss9sktsMPn3` that only allows updates via proofs and an init() method, meaning this can't be redeployed to reinitialize the state.

Draft as breaks existing tests as had to remove all @methods as the only way to update the state has to be through the `sendReward` method.